### PR TITLE
Added .kts extension to Kotlin language

### DIFF
--- a/languages/kt.xml
+++ b/languages/kt.xml
@@ -1,5 +1,5 @@
 <NotepadPlus>
-    <UserLang name="Kotlin" ext="kt" udlVersion="2.1">
+    <UserLang name="Kotlin" ext="kt kts" udlVersion="2.1">
         <Settings>
             <Global caseIgnored="no" allowFoldOfComments="yes" foldCompact="yes" forcePureLC="0" decimalSeparator="0" />
             <Prefix Keywords1="no" Keywords2="no" Keywords3="no" Keywords4="no" Keywords5="yes" Keywords6="yes" Keywords7="yes" Keywords8="no" />


### PR DESCRIPTION
`.kts` is one of the officially supported extensions, it used to write gradle build files for example.